### PR TITLE
Change to 250 characters max as said in the fb doc

### DIFF
--- a/src/MessengerPlugin.jsx
+++ b/src/MessengerPlugin.jsx
@@ -14,8 +14,8 @@ export default class MessengerPlugin extends Component {
                     return new Error(`Invalid prop ${propName}: must be a string.`);
                 }
 
-                if (props[propName].length > 50) {
-                    return new Error(`Invalid prop ${propName}: must be smaller than 50 characters.`);
+                if (props[propName].length > 250) {
+                    return new Error(`Invalid prop ${propName}: must be smaller than 250 characters.`);
                 }
             }
         },


### PR DESCRIPTION
Hi,
The doc say it's max 250 characters. Not 50.
https://developers.facebook.com/docs/messenger-platform/plugin-reference/send-to-messenger