### PR TITLE
Use PropTypes from 'prop-types' package

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "esformatter-quotes": "1.0.3",
     "eslint": "2.3.0",
     "eslint-plugin-react": "4.2.3",
+    "prop-types": "15.5.10",
     "react": "0.14.7",
     "react-dom": "0.14.7",
     "release-script": "1.0.2"

--- a/src/MessengerPlugin.jsx
+++ b/src/MessengerPlugin.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 
 export default class MessengerPlugin extends Component {


### PR DESCRIPTION
Fixes: Warning: Accessing PropTypes via the main React package is deprecated.
Use the prop-types package from npm instead.